### PR TITLE
update geth dependency for new signing hash code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/libp2p/go-libp2p v0.24.0
 	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/protolambda/ztyp v0.2.2
+	github.com/prysmaticlabs/fastssz v0.0.0-20221107182844-78142813af44
+	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7
 	github.com/prysmaticlabs/prysm/v3 v3.2.0-rc.0.0.20221215090238-7866e8a1967f
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli v1.22.9
@@ -124,8 +126,6 @@ require (
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/prometheus/prom2json v1.3.0 // indirect
 	github.com/protolambda/go-kzg v0.0.0-20221129234330-612948a21fb0 // indirect
-	github.com/prysmaticlabs/fastssz v0.0.0-20221107182844-78142813af44 // indirect
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7 // indirect
 	github.com/prysmaticlabs/gohashtree v0.0.2-alpha // indirect
 	github.com/prysmaticlabs/prombbolt v0.0.0-20210126082820-9b7adba6db7c // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
@@ -186,4 +186,4 @@ require (
 
 )
 
-replace github.com/ethereum/go-ethereum => github.com/mdehoog/go-ethereum v1.10.19-0.20221208223223-b697b4457653
+replace github.com/ethereum/go-ethereum => github.com/mdehoog/go-ethereum v1.10.19-0.20230108160323-2b556dbb6624

--- a/go.sum
+++ b/go.sum
@@ -516,8 +516,8 @@ github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/mdehoog/go-ethereum v1.10.19-0.20221208223223-b697b4457653 h1:BrWAZY70WNKeiI1Ef/z8GL5W2LZPXvfVYp2m1ysZGyA=
-github.com/mdehoog/go-ethereum v1.10.19-0.20221208223223-b697b4457653/go.mod h1:W41sbHJMVm08zh2cYC2q/wMaxxjBVhiu+pn37bybMH4=
+github.com/mdehoog/go-ethereum v1.10.19-0.20230108160323-2b556dbb6624 h1:l3HWY+BQ5bfJJMIwwo8y+EeklWAaK4NS6ed3kjnR03o=
+github.com/mdehoog/go-ethereum v1.10.19-0.20230108160323-2b556dbb6624/go.mod h1:vs0eQitDQMsQfYyR10j++6s1EZ8/6otthAzf332eWGk=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=


### PR DESCRIPTION
cc: @terencechain

This is required for blob-utils to work with the latest geth blob tx signing changes.