### PR TITLE
Fix transaction encoding

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
 
 	"github.com/urfave/cli"
@@ -154,7 +153,7 @@ func TxApp(cliCtx *cli.Context) error {
 	signedTx, _ := types.SignTx(tx, types.NewCancunSigner(chainId), key)
 	txWithBlobs := types.NewBlobTxWithBlobs(signedTx, blobs, commitments, proofs)
 
-	rlpData, _ := rlp.EncodeToBytes(txWithBlobs)
+	rlpData, _ := txWithBlobs.MarshalBinary()
 	err = client.Client().CallContext(context.Background(), nil, "eth_sendRawTransaction", hexutil.Encode(rlpData))
 
 	if err != nil {


### PR DESCRIPTION
@Inphi apologies, I just realized I missed a change in the earlier PR, I was actually testing with this version using `txWithBlobs.MarshalBinary()` to encode the tx, which I think additionally adds the `TxType: 0x03`

The previous version no longer works for me and returns this error:
> 2023/08/18 13:14:32 failed to send transaction: rlp: expected input list for types.LegacyTx
